### PR TITLE
リロードした時に両者の画面がmatchedの状態になってしまうバグを修正

### DIFF
--- a/src/app/(games)/connect4/[roomId]/page.tsx
+++ b/src/app/(games)/connect4/[roomId]/page.tsx
@@ -26,6 +26,7 @@ export default function Page({ params }: { params: Promise<{ roomId: string }> }
 	const socketRef = useRef<Socket | null>(null);
 	const suppressSyncRef = useRef<boolean>(false);
 	const membersRef = useRef<number>(0);
+	const matchStateRef = useRef<MatchState>("waiting");
 
 	const getRandomTurn = () => {
 		if (getRandomInt(2) === 0)
@@ -49,7 +50,7 @@ export default function Page({ params }: { params: Promise<{ roomId: string }> }
 		};
 
 		const handleRoomPaired = ({ roomId: pairedRoomId }: { roomId: string }) => {
-			if (pairedRoomId === roomId) {
+			if (pairedRoomId === roomId && matchStateRef.current === "waiting") {
 				setMatchState("matched");
 				pairedTimer = setTimeout(() => {
 					setMatchState("playing");
@@ -126,6 +127,10 @@ export default function Page({ params }: { params: Promise<{ roomId: string }> }
 			return () => clearTimeout(timer);
 		}
 	}, [board]);
+
+	useEffect(() => {
+		matchStateRef.current = matchState;
+	}, [matchState]);
 
 	useUpdateEffect(() => {
 		if (firstTurn === "random") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matchmaking reliability in Connect 4 rooms to prevent premature or incorrect pairings.
  * Ensured game state transitions occur only when the correct room is paired, reducing false starts.
  * Synchronized internal game state to avoid unexpected shifts during countdown and game start.

* **Chores**
  * Minor stability adjustments to support smoother countdowns and transitions from waiting to playing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->