### PR TITLE
タイトルの位置を変更

### DIFF
--- a/src/components/Connect4/Board.tsx
+++ b/src/components/Connect4/Board.tsx
@@ -20,14 +20,14 @@ export default function Board({ board, onCellClick, isWin, setIsWin, onRestart, 
 
 	return (
 		<div className="relative z-1">
-			<Result isWin={isWin} onRestart={onRestart} handleCancel={handleCancel} onShowGames={onShowGames} currentTurn={currentTurn}/>
+			<Result isWin={isWin} onRestart={onRestart} handleCancel={handleCancel} onShowGames={onShowGames} currentTurn={currentTurn} />
 			<TurnDisc currentTurn={currentTurn} />
+			<div className="pt-2 pl-2">
+				<h2 className="text-2xl font-bold text-blue-800">Connect 4</h2>
+			</div>
 			<div className="flex flex-col items-center p-6">
-				<div className="-translate-x-35">
-					<h2 className="text-2xl font-bold mb-4 text-blue-800">Connect 4</h2>
-				</div>
 				{/* 盤面 */}
-				<div className="bg-blue-600 p-4 rounded-lg shadow-lg">
+				<div className="bg-blue-600 p-4 rounded-lg shadow-lg mt-2">
 					<div className="grid grid-cols-7 gap-2">
 						{board.map((row, rowIndex) =>
 							row.map((cell, colIndex) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the “Connect 4” title to a header above the board for clearer visual hierarchy.
  * Increased spacing around the board to improve readability and layout consistency.
  * Kept result and turn indicators in place; gameplay and grid behavior unchanged.

* **Refactor**
  * Restructured component layout to simplify header and board arrangement without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->