### PR TITLE
URLをコピーできるボタンの追加

### DIFF
--- a/src/app/(games)/connect4/[roomId]/page.tsx
+++ b/src/app/(games)/connect4/[roomId]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { use } from "react";
-import { Board, Loading, ShowTurn, RuleSettings, TemporaryWaiting } from "@/components/Connect4";
+import { Board, Loading, ShowTurn, RuleSettings, TemporaryWaiting, CopyUrl } from "@/components/Connect4";
 import styles from "@/styles/Utils.module.scss";
 
 // カスタムフック
@@ -49,8 +49,9 @@ export default function Page({ params }: { params: Promise<{ roomId: string }> }
 			<>
 				<div className="flex flex-col justify-center items-center min-h-[calc(100vh-72px)]">
 					<Loading text="対線相手を待っています…" />
-					<div className="mt-7">
+					<div className="flex flex-row gap-2 mt-7">
 						<RuleSettings setFirst={setFirstTurn} />
+						<CopyUrl />
 					</div>
 				</div>
 			</>

--- a/src/components/Connect4/CopyUrl.tsx
+++ b/src/components/Connect4/CopyUrl.tsx
@@ -1,0 +1,15 @@
+import { Button } from "antd";
+
+export default function CopyUrl() {
+	const copyUrl = () => {
+		navigator.clipboard.writeText(`URLを押して、コネクト４を一緒にプレイしよう！🎉\n\n${window.location.href}`);
+	}
+	
+	return (
+		<div>
+			<Button type="primary" onClick={() => copyUrl()}>
+				招待URLをコピー
+			</Button>
+		</div>
+	)
+}

--- a/src/components/Connect4/index.ts
+++ b/src/components/Connect4/index.ts
@@ -3,3 +3,4 @@ export { default as ShowTurn } from "./PlayerInfo";
 export { default as RuleSettings } from "./GameRule";
 export { default as Loading } from "./Loading";
 export { default as TemporaryWaiting } from "./TemporaryWaiting";
+export { default as CopyUrl } from "./CopyUrl";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy invite URL” button on the Connect4 waiting screen to quickly share a match link.
* **Style**
  * Updated the waiting screen layout to arrange controls horizontally with spacing, placing the invite action alongside rule settings for a cleaner, more accessible experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->