### PR TITLE
そのゲームのMAX_PLAYERを超えた場合の表示処理

### DIFF
--- a/src/app/(games)/connect4/[roomId]/page.tsx
+++ b/src/app/(games)/connect4/[roomId]/page.tsx
@@ -2,8 +2,8 @@
 
 import { use } from "react";
 import { Board, ShowTurn, TemporaryWaiting, ReShowResult } from "@/components/Connect4";
-import { Loading, RuleSettings, CopyUrl } from "@/components/Utils";
-import { keyToShowLabel, firstTurnItems, Role, mainPlayerColorClass } from "@/constants/connect4";
+import { Loading, RuleSettings, CopyUrl, NewRoom } from "@/components/Utils";
+import { keyToShowLabel, firstTurnItems, Role, mainPlayerColorClass, MAX_PLAYERS } from "@/constants/connect4";
 import styles from "@/styles/Utils.module.scss";
 
 // カスタムフック
@@ -50,6 +50,20 @@ export default function Page({ params }: { params: Promise<{ roomId: string }> }
 	});
 
 	if (matchState === "waiting") {
+		// ルームが満員の場合
+		if (members > MAX_PLAYERS) {
+			return (
+				<>
+					<div className="flex flex-col justify-center items-center min-h-[calc(100vh-72px)]">
+						<Loading text="ルームが満員です。再度ルームを作成してください。" />
+						<div className="flex flex-row mt-7">
+							<NewRoom gameName="connect4" />
+						</div>
+					</div>
+				</>
+			);
+		}
+		// ルームが空いている場合
 		return (
 			<>
 				<div className="flex flex-col justify-center items-center min-h-[calc(100vh-72px)]">

--- a/src/app/(games)/reversi/[roomId]/page.tsx
+++ b/src/app/(games)/reversi/[roomId]/page.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import { use } from "react";
-import { Loading, RuleSettings, CopyUrl } from "@/components/Utils";
-import { keyToShowLabel, firstTurnItems, Role, mainPlayerColorClass } from "@/constants/reversi";
+import { Loading, RuleSettings, CopyUrl, NewRoom } from "@/components/Utils";
+import { keyToShowLabel, firstTurnItems, Role, mainPlayerColorClass, MAX_PLAYERS } from "@/constants/reversi";
 import { Board, Result, SkipTurn } from "@/components/Reversi";
 import closeModal from "@/utils/closeModal";
 // カスタムフック
@@ -56,6 +56,20 @@ export default function Page({ params }: { params: Promise<{ roomId: string }> }
 	const gotoTopPage = useGotoTopPage();
 
 	if (matchState === "waiting") {
+		// ルームが満員の場合
+		if (members > MAX_PLAYERS) {
+			return (
+				<>
+					<div className="flex flex-col justify-center items-center min-h-[calc(100vh-72px)]">
+						<Loading text="ルームが満員です。再度ルームを作成してください。" />
+						<div className="flex flex-row mt-7">
+							<NewRoom gameName="reversi" />
+						</div>
+					</div>
+				</>
+			);
+		}
+		// ルームが空いている場合
 		return (
 			<>
 				<div className="flex flex-col justify-center items-center min-h-[calc(100vh-72px)]">

--- a/src/components/Utils/NewRoom.tsx
+++ b/src/components/Utils/NewRoom.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button } from "antd";
+import { useRouter } from "next/navigation";
+
+/**
+ * 新規ルーム作成用のコンポーネント
+ * 
+ * @description
+ * 指定されたゲームの新規ルーム作成ページへ遷移するボタンを表示します。
+ * ボタンをクリックすると、`/{gameName}/newRoom` のパスへナビゲートします。
+ * 
+ * @param props - コンポーネントのプロパティ
+ * @param props.gameName - ゲームの名前（例: "reversi", "connect4"）
+ * 
+ * @returns 新規ルーム作成ボタンを含むReact要素
+ * 
+ * @example
+ * ```tsx
+ * <NewRoom gameName="reversi" />
+ * ```
+ */
+export default function NewRoom({ gameName }: { gameName: string }) {
+	const router = useRouter();
+
+	return (
+		<>
+			<div>
+				<Button type="primary" onClick={() => router.push(`/${gameName}/newRoom`)}>
+					新規ルームを作成
+				</Button>
+			</div>
+		</>
+	)
+}

--- a/src/components/Utils/index.ts
+++ b/src/components/Utils/index.ts
@@ -1,3 +1,4 @@
 export { default as Loading } from "./Loading";
 export { default as RuleSettings } from "./GameRule";
 export { default as CopyUrl } from "./CopyUrl";
+export { default as NewRoom } from "./NewRoom";

--- a/src/constants/connect4.ts
+++ b/src/constants/connect4.ts
@@ -30,3 +30,5 @@ export const firstTurnItems = [
 ]
 
 export const mainPlayerColorClass = "text-red-500" as const;
+
+export const MAX_PLAYERS = 2 as const;

--- a/src/constants/reversi.ts
+++ b/src/constants/reversi.ts
@@ -38,3 +38,5 @@ export const firstTurnItems = [
 export const mainPlayerColorClass = "text-gray-900" as const;
 
 export const MAX_CELL_COUNT = 64 as const;
+
+export const MAX_PLAYERS = 2 as const;


### PR DESCRIPTION
close #53 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When a room exceeds MAX_PLAYERS in Connect4/Reversi, show a full-room message and a NewRoom button; add MAX_PLAYERS constants and a reusable NewRoom component.
> 
> - **Games (Connect4/Reversi)**:
>   - Show full-room state in `src/app/(games)/(connect4|reversi)/[roomId]/page.tsx` when `members > MAX_PLAYERS`, displaying a message and `NewRoom` action.
>   - Retain existing waiting UI when room is not full.
> - **Utils**:
>   - Add `NewRoom` component (`src/components/Utils/NewRoom.tsx`) and export via `src/components/Utils/index.ts`.
> - **Constants**:
>   - Define `MAX_PLAYERS = 2` in `src/constants/connect4.ts` and `src/constants/reversi.ts` and import where used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48820a792000d092aa7c578ab9a08632f4b1c140. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When a game room reaches maximum capacity, players now see a "room full" notification with an option to create a new room instead of waiting.
  * Full-room handling is now available for Connect4 and Reversi games.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->