### PR TITLE
リバーシにも途中退出モーダルを表示

### DIFF
--- a/src/app/(games)/connect4/[roomId]/page.tsx
+++ b/src/app/(games)/connect4/[roomId]/page.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import { use } from "react";
-import { Board, ShowTurn, TemporaryWaiting, ReShowResult } from "@/components/Connect4";
-import { Loading, RuleSettings, CopyUrl, NewRoom } from "@/components/Utils";
+import { Board, ShowTurn, ReShowResult } from "@/components/Connect4";
+import { Loading, RuleSettings, CopyUrl, NewRoom, TemporaryWaiting } from "@/components/Utils";
 import { keyToShowLabel, firstTurnItems, Role, mainPlayerColorClass, MAX_PLAYERS } from "@/constants/connect4";
 import styles from "@/styles/Utils.module.scss";
 

--- a/src/app/(games)/reversi/[roomId]/page.tsx
+++ b/src/app/(games)/reversi/[roomId]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { use } from "react";
-import { Loading, RuleSettings, CopyUrl, NewRoom } from "@/components/Utils";
+import { Loading, RuleSettings, CopyUrl, NewRoom, TemporaryWaiting } from "@/components/Utils";
 import { keyToShowLabel, firstTurnItems, Role, mainPlayerColorClass, MAX_PLAYERS } from "@/constants/reversi";
 import { Board, Result, SkipTurn } from "@/components/Reversi";
 import closeModal from "@/utils/closeModal";
@@ -102,6 +102,7 @@ export default function Page({ params }: { params: Promise<{ roomId: string }> }
 				currentRole={currentRole}
 				onCellClick={onCellClick}
 			/>
+			<TemporaryWaiting members={members} />
 		</div>
 	)
 }

--- a/src/components/Connect4/index.ts
+++ b/src/components/Connect4/index.ts
@@ -1,4 +1,3 @@
 export { default as Board } from "./Board";
 export { default as ShowTurn } from "./PlayerInfo";
-export { default as TemporaryWaiting } from "./TemporaryWaiting";
 export { default as ReShowResult } from "./ReShowResult";

--- a/src/components/Utils/TemporaryWaiting.tsx
+++ b/src/components/Utils/TemporaryWaiting.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { Modal, Button, Spin } from "antd";
+import { LoadingOutlined } from "@ant-design/icons";
+import { useState, useEffect } from "react";
+import useGotoTopPage from "@/hooks/utils/useGotoTopPage";
+
+/**
+ * オンライン対戦で対戦相手の参加を待つ待機モーダルコンポーネントです。
+ * メンバー数が2人未満の場合に自動的に表示されます。
+ * 
+ * @param props - コンポーネントのProps
+ * @param props.members - 現在のルームメンバー数
+ * 
+ * @remarks
+ * - メンバー数が2人未満の場合にモーダルが表示されます
+ * - ローディングスピナーで待機中であることを視覚的に示します
+ * - 退出ボタンからトップページに戻ることができます
+ * - 2人目が参加すると自動的にモーダルが閉じます
+ */
+export default function TemporaryWaiting({ members }: { members: number }) {
+	const [isOpen, setIsOpen] = useState(false);
+	const gotoTopPage = useGotoTopPage();
+
+	useEffect(() => {
+		if (members < 2)
+			setIsOpen(true);
+		else
+			setIsOpen(false);
+	}, [members]);
+
+	return (
+		<Modal
+			open={isOpen}
+			title="対戦相手を待っています..."
+			onCancel={undefined}
+			footer={[
+				<Button key="root" type="primary" onClick={() => gotoTopPage(setIsOpen)}>
+					退出する
+				</Button>,
+			]}
+		>
+			<div className="flex justify-center items-center my-4">
+				<Spin indicator={<LoadingOutlined spin />} size="large" />
+			</div>
+		</Modal>
+	)
+}

--- a/src/components/Utils/index.ts
+++ b/src/components/Utils/index.ts
@@ -2,3 +2,4 @@ export { default as Loading } from "./Loading";
 export { default as RuleSettings } from "./GameRule";
 export { default as CopyUrl } from "./CopyUrl";
 export { default as NewRoom } from "./NewRoom";
+export { default as TemporaryWaiting } from "./TemporaryWaiting";


### PR DESCRIPTION
close #60 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 73f56d73f03dedd7d292184f457012dd4b3755aa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reversi game now displays a waiting modal when awaiting opponent to join.

* **Refactor**
  * Reorganized waiting component across module structure for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->