### PR TITLE
Reduce room ID generation attempts to shared constant

### DIFF
--- a/src/app/api/rooms/new/route.ts
+++ b/src/app/api/rooms/new/route.ts
@@ -1,4 +1,5 @@
 export const dynamic = "force-dynamic";
+import { MAX_ROOM_ID_GENERATION_ATTEMPTS } from "@/constants/utils";
 import { getRandomInt } from "@/utils/getRandom";
 
 const MIN_ROOM_ID_NUMBER = Number(process.env.ROOMID_MIN);
@@ -12,12 +13,12 @@ const MAX_ROOM_ID_NUMBER = Number(process.env.ROOMID_MAX);
  * @remarks
  * - 環境変数で設定された範囲内でランダムな数値を生成します
  * - バックエンドサーバーに問い合わせて、既に存在しないIDを確認します
- * - 一意なIDが見つかるまで繰り返します
+ * - 最大10回まで一意なIDを探索します
  * - 生成された数値は16進数文字列に変換されます
  */
 async function generateRoomId() {
-	while (true) {
-		const roomIdNumber = BigInt(getRandomInt(MIN_ROOM_ID_NUMBER, MAX_ROOM_ID_NUMBER));
+        for (let attempt = 0; attempt < MAX_ROOM_ID_GENERATION_ATTEMPTS; attempt++) {
+                const roomIdNumber = BigInt(getRandomInt(MIN_ROOM_ID_NUMBER, MAX_ROOM_ID_NUMBER));
 
 		const env = process.env.NEXT_PUBLIC_ENV;
 		const backendUrl = env === "local"
@@ -30,10 +31,12 @@ async function generateRoomId() {
 				if (!data.exists)
 					return roomIdNumber.toString(16);
 			}
-		} catch {
-			return null;
-		}
-	}
+                } catch {
+                        return null;
+                }
+        }
+
+        return null;
 }
 
 export async function GET() {

--- a/src/constants/utils.ts
+++ b/src/constants/utils.ts
@@ -1,4 +1,6 @@
 export const Role = {
-	MAIN: 1,
-	SUB: 2,
+        MAIN: 1,
+        SUB: 2,
 } as const;
+
+export const MAX_ROOM_ID_GENERATION_ATTEMPTS = 10;


### PR DESCRIPTION
## Summary
- expose a MAX_ROOM_ID_GENERATION_ATTEMPTS constant under src/constants/utils.ts
- update the room creation API to use the shared constant and lower the retry cap to 10
- refresh documentation comment to reflect the new limit

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691683825764832aad73b49e5b1387f5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limit room ID generation attempts to a shared constant (10) and update the room creation API to use it.
> 
> - **Backend/API**:
>   - `src/app/api/rooms/new/route.ts`
>     - Replace infinite loop with for-loop capped by `MAX_ROOM_ID_GENERATION_ATTEMPTS`.
>     - Import and use shared constant; return `null` after exhausting attempts; update remarks to note 10-attempt limit.
> - **Constants**:
>   - Add `MAX_ROOM_ID_GENERATION_ATTEMPTS = 10` in `src/constants/utils.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8f9a4b8f20b3a5dc2c0a06fc0426a31b2858663. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->