### PR TITLE
軽微なuseEffectの修正

### DIFF
--- a/src/hooks/connect4/_internal/useConnect4SocketSync.ts
+++ b/src/hooks/connect4/_internal/useConnect4SocketSync.ts
@@ -55,5 +55,6 @@ export function useConnect4SocketSync({
 			currentRole,
 			lastPosition,
 		});
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [board]);
 }

--- a/src/hooks/connect4/useConnect4Room.ts
+++ b/src/hooks/connect4/useConnect4Room.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { createSocket } from "@/libs/socket/client";
+import { useUpdateEffect } from "@/hooks/utils/useUpdateEffect";
 import { MatchState, RoleState, HandleJoinedRoomProps, FirstState } from "@/types/connect4";
 import { Role } from "@/constants/connect4";
 import type { Socket } from "socket.io-client";
@@ -93,7 +94,7 @@ export default function useConnect4Room(
 	}, [roomId]);
 
 	// 先手設定の変更をサーバへ通知（単一ソケットで管理）
-	useEffect(() => {
+	useUpdateEffect(() => {
 		if (!socketRef.current) return;
 		socketRef.current.emit("setFirstRole", { roomId, firstRole });
 	}, [firstRole, roomId]);

--- a/src/hooks/reversi/_internal/useReversiSocketSync.ts
+++ b/src/hooks/reversi/_internal/useReversiSocketSync.ts
@@ -55,5 +55,6 @@ export function useReversiSocketSync({
 			currentRole,
 			lastPosition,
 		});
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [board]);
 }

--- a/src/hooks/reversi/useReversiRoom.ts
+++ b/src/hooks/reversi/useReversiRoom.ts
@@ -98,7 +98,7 @@ export default function useReversiRoom(
 	useUpdateEffect(() => {
 		if (!socketRef.current) return;
 		socketRef.current.emit("setFirstRole", { roomId, firstRole });
-	}, [firstRole]);
+	}, [firstRole, roomId]);
 
 	const emitRestart = useCallback(() => {
 		socketRef.current?.emit("restart", roomId);


### PR DESCRIPTION
#99 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines effect dependencies and emissions for game rooms, adding exhaustive-deps suppressions for board sync and correcting first-role update triggers.
> 
> - **Connect4**:
>   - `useConnect4Room`: switch to `useUpdateEffect` for `setFirstRole` emission; include `roomId` in deps.
>   - `useConnect4SocketSync`: add `// eslint-disable-next-line react-hooks/exhaustive-deps` to board-sync effect.
> - **Reversi**:
>   - `useReversiRoom`: include `roomId` in `useUpdateEffect` deps for `setFirstRole` emission.
>   - `useReversiSocketSync`: add `// eslint-disable-next-line react-hooks/exhaustive-deps` to board-sync effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c4e8f4b184d9f9fbbb6eaec586253590ae6198d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * Connect4およびReversiゲームのルーム初期化処理を改善
  * サーバー同期のトリガー条件を調整

* **その他**
  * コード品質チェック設定の最適化

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->